### PR TITLE
bin/teallach-nitrogen: make the wallpaper survive

### DIFF
--- a/bin/teallach-nitrogen
+++ b/bin/teallach-nitrogen
@@ -130,9 +130,14 @@ class Window(QDialog):
         items = self.scene.selectedItems()
         if len(items) > 0:
             image = items[0].get_filename()
-            print(f'Set {image}')
             os.system('pkill swaybg')
             mode = self.mode if self.mode is not None else 'fill'
+            with open(os.path.join(os.path.expanduser('~'), '.config/teallach', "wallrc"), "w", encoding="utf-8") as f:
+              f.write(f'IMAGE={image}\n')
+            with open(os.path.join(os.path.expanduser('~'), '.config/teallach', "wallrc"), "a", encoding="utf-8") as f:
+              f.write(f'MODE={mode}\n')
+            with open(os.path.join(os.path.expanduser('~'), '.config/teallach', "wallrc"), "r", encoding="utf-8") as f:
+              print(f.read())
             os.system(f'nohup swaybg -i "{image}" -m {mode} >/dev/null &')
 
     def mode_combobox_text_changed(self, s):

--- a/usr/share/teallach/autostart
+++ b/usr/share/teallach/autostart
@@ -1,2 +1,6 @@
-swaybg -i ~/.local/share/images/teallach/wallpapers/tile.png -m tile >/dev/null 2>&1 &
-
+if [ -r ~/.config/teallach/wallrc ]; then
+  . ~/.config/teallach/wallrc
+  swaybg -i "$IMAGE" -m "$MODE" >/dev/null 2>&1 &
+else
+  swaybg -i ~/.local/share/images/teallach/wallpapers/tile.png -m tile >/dev/null 2>&1 &
+fi


### PR DESCRIPTION
- prints the image and mode to a config file
- adjusts autostart to source the image and mode